### PR TITLE
Improve dashboard experience

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import SignupPage       from './pages/SignupPage';
 import CountrySelect    from './pages/CountrySelect';
 import ElectionPage     from './pages/ElectionPage';
 import AdminPage        from './pages/AdminPage';
+import Header           from './components/Header';
 import StatsPage        from './pages/StatsPage';
 
 import DashboardLayout  from './components/DashboardLayout';
@@ -19,6 +20,7 @@ function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
+        <Header />
         <Routes>
           <Route path="/login"           element={<LoginPage />} />
           <Route path="/signup"          element={<SignupPage />} />

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -14,15 +14,24 @@ export default function Header() {
   return (
     <header className="header">
       <nav>
-        <Link to="/election">Election</Link>
-        <Link to="/dashboard">Dashboard</Link>
-        {user?.role === 'admin' && (
-          <Link to="/admin">Admin</Link>
+        {user ? (
+          <>
+            <Link to="/election">Election</Link>
+            <Link to="/dashboard">Dashboard</Link>
+            {user.role === 'admin' && <Link to="/admin">Admin</Link>}
+          </>
+        ) : (
+          <>
+            <Link to="/login">Login</Link>
+            <Link to="/signup">Sign Up</Link>
+          </>
         )}
       </nav>
-      <button onClick={handleLogout} className="button logout-button">
-        Logout
-      </button>
+      {user && (
+        <button onClick={handleLogout} className="button logout-button">
+          Logout
+        </button>
+      )}
     </header>
   );
 }

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Modal({ open, onClose, children }) {
+  if (!open) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={e => e.stopPropagation()}>
+        <button className="modal-close button logout-button" onClick={onClose}>
+          &times;
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/BuildPage.jsx
+++ b/client/src/pages/BuildPage.jsx
@@ -22,8 +22,9 @@ export default function BuildPage() {
         // filter cities for this country
         setTypes(btRes.data);
         setCities(cityRes.data.filter(c => c.country._id === countryId));
-      } catch {
-        setError('Failed to load build data');
+      } catch (e) {
+        console.error(e);
+        setError(e.response?.data?.error || 'Failed to load build data');
       }
     }
     if (countryId) load();

--- a/client/src/pages/BuyUnitsPage.jsx
+++ b/client/src/pages/BuyUnitsPage.jsx
@@ -19,8 +19,9 @@ export default function BuyUnitsPage() {
       try {
         const res = await client.get(`/dashboard/${countryId}/unit-types`);
         setUnits(res.data);
-      } catch {
-        setError('Failed to load unit types');
+      } catch (e) {
+        console.error(e);
+        setError(e.response?.data?.error || 'Failed to load unit types');
       }
     }
     if (countryId) loadUnitTypes();

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -1,13 +1,19 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
 export default function LoginPage() {
-  const { login } = useContext(AuthContext);
+  const { user, login } = useContext(AuthContext);
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    if (user.role === 'president') navigate('/dashboard', { replace: true });
+    else navigate('/election', { replace: true });
+  }, [user, navigate]);
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -44,6 +50,9 @@ export default function LoginPage() {
           Log In
         </button>
       </form>
+      <p className="text-center mt-2 text-sm">
+        Need an account? <Link to="/signup" className="text-blue-600">Sign Up</Link>
+      </p>
     </div>
   );
 }

--- a/client/src/pages/OverviewPage.jsx
+++ b/client/src/pages/OverviewPage.jsx
@@ -3,17 +3,26 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
 import client from '../api/client';
+import BuyUnitsPage from './BuyUnitsPage';
+import SendUnitsPage from './SendUnitsPage';
+import BuildPage from './BuildPage';
+import Modal from '../components/Modal';
 
 export default function OverviewPage() {
   const { user } = useContext(AuthContext);
   const [data, setData] = useState(null);
+  const [resource, setResource] = useState(null);
   const [err, setErr]   = useState('');
+  const [showBuy,  setShowBuy]  = useState(false);
+  const [showSend, setShowSend] = useState(false);
+  const [showBuild,setShowBuild]= useState(false);
 
   useEffect(() => {
     async function loadOverview() {
       try {
         const res = await client.get(`/dashboard/${user.country}/overview`);
         setData(res.data);
+        setResource(res.data.resource);
       } catch {
         setErr('Failed to load overview');
       }
@@ -21,18 +30,49 @@ export default function OverviewPage() {
     if (user?.country) loadOverview();
   }, [user]);
 
+  useEffect(() => {
+    if (!resource) return;
+    const id = setInterval(() => {
+      setResource(r => ({
+        ...r,
+        moneyCents: r.moneyCents + r.moneyCentsPerSecond,
+        oilUnits:   r.oilUnits + r.oilUnitsPerSecond
+      }));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [resource]);
+
   if (err) return <div className="text-red-600 p-4">{err}</div>;
-  if (!data) return <div className="p-4">Loading overview…</div>;
+  if (!data || !resource) return <div className="p-4">Loading overview…</div>;
 
   return (
     <div className="space-y-6">
       {/* Resources */}
       <section className="bg-white shadow rounded p-6">
         <h2 className="text-xl font-semibold mb-4">Resources</h2>
-        <p>Money/sec: ${(data.resource.moneyCentsPerSecond / 100).toFixed(2)}</p>
-        <p>Oil/sec: {data.resource.oilUnitsPerSecond}</p>
+        <p>Money: ${(resource.moneyCents / 100).toFixed(2)}</p>
+        <p>Oil: {resource.oilUnits.toFixed(0)}</p>
+        <p className="text-sm text-gray-600">
+          +{(resource.moneyCentsPerSecond / 100).toFixed(2)}/sec,
+          +{resource.oilUnitsPerSecond}/sec
+        </p>
         <p>Land used: {data.usedLand} / {data.landLimit}</p>
+        <div className="mt-4 space-x-2">
+          <button className="button" onClick={() => setShowBuy(true)}>Buy Units</button>
+          <button className="button" onClick={() => setShowSend(true)}>Send Units</button>
+          <button className="button" onClick={() => setShowBuild(true)}>Build</button>
+        </div>
       </section>
+
+      <Modal open={showBuy} onClose={() => setShowBuy(false)}>
+        <BuyUnitsPage />
+      </Modal>
+      <Modal open={showSend} onClose={() => setShowSend(false)}>
+        <SendUnitsPage />
+      </Modal>
+      <Modal open={showBuild} onClose={() => setShowBuild(false)}>
+        <BuildPage />
+      </Modal>
 
       {/* Pending Events */}
       <section className="bg-white shadow rounded p-6">

--- a/client/src/pages/SendUnitsPage.jsx
+++ b/client/src/pages/SendUnitsPage.jsx
@@ -26,8 +26,9 @@ export default function SendUnitsPage() {
         setInventory(invRes.data);
         // exclude own country
         setCountries(ctrRes.data.filter(c => c._id !== cid));
-      } catch {
-        setError('Failed to load inventory or countries');
+      } catch (e) {
+        console.error(e);
+        setError(e.response?.data?.error || 'Failed to load inventory or countries');
       }
     }
     load();

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -1,14 +1,20 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { AuthContext } from '../contexts/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
 export default function SignupPage() {
-  const { signup } = useContext(AuthContext);
+  const { user, signup } = useContext(AuthContext);
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [country, setCountry] = useState('');
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    if (user.role === 'president') navigate('/dashboard', { replace: true });
+    else navigate('/election', { replace: true });
+  }, [user, navigate]);
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -53,6 +59,10 @@ export default function SignupPage() {
           Sign Up
         </button>
       </form>
+      <p className="text-center mt-2 text-sm">
+        Already have an account?{' '}
+        <Link to="/login" className="text-blue-600">Log In</Link>
+      </p>
     </div>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -88,3 +88,33 @@ body {
   height: 100%;
   width: 100%;
 }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  max-height: 90vh;
+  overflow-y: auto;
+  width: 90%;
+  max-width: 500px;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- show Header with logout across app
- integrate buy, send and build forms into dashboard via Modal component
- animate money and oil counters
- add small error logging for dashboard utilities
- hide logout on auth pages and redirect logged in users

## Testing
- `npm test --silent` *(fails: npm: command not found)*
- `npm --prefix client test --silent` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465e4c84208325a0e723c5dd4274d3